### PR TITLE
Add Teensy hardware definition and fix keywords.txt file

### DIFF
--- a/SoftPWM_timer.h
+++ b/SoftPWM_timer.h
@@ -25,6 +25,8 @@
 // allow certain chips to use different timers
 #if defined(__AVR_ATmega32U4__)
 #define USE_TIMER4_HS // Teensy 2.0 lacks timer2, but has high speed timer4 :-)
+#elif defined(__arm__) && defined(TEENSYDUINO)
+#define USE_INTERVALTIMER  // Teensy 3.x has special interval timers :-)
 #else
 #define USE_TIMER2
 #endif
@@ -52,6 +54,17 @@
   OCR4C  = 0; \
   OCR4C  = (ocr); \
   TIMSK4  = (1 << OCIE4A); \
+})
+#elif defined(USE_INTERVALTIMER)
+#define SOFTPWM_TIMER_INTERRUPT    softpwm_interval_timer
+#ifdef ISR
+#undef ISR
+#endif
+#define ISR(f) void f(void)
+#define SOFTPWM_TIMER_SET(val)
+#define SOFTPWM_TIMER_INIT(ocr) ({\
+  IntervalTimer *t = new IntervalTimer(); \
+  t->begin(softpwm_interval_timer, 1000000.0 / (float)(SOFTPWM_FREQ * 256)); \
 })
 #endif
 

--- a/examples/SoftPWM_Wiring_HeartBeat/SoftPWM_Wiring_HeartBeat.pde
+++ b/examples/SoftPWM_Wiring_HeartBeat/SoftPWM_Wiring_HeartBeat.pde
@@ -1,5 +1,9 @@
 #include <SoftPWM.h>
 
+#ifndef WLED
+#define WLED LED_BUILTIN
+#endif
+
 void setup()
 {
   SoftPWMBegin();

--- a/keywords.txt
+++ b/keywords.txt
@@ -13,24 +13,24 @@
 # Datatypes (KEYWORD5 or KEYWORD1)
 ########################################
 
-SoftPWM                         KEYWORD1
+SoftPWM	KEYWORD1
 
 ########################################
 # Methods and Functions
 #   (FUNCTION2 or KEYWORD2)
 ########################################
 
-SoftPWMSet                      KEYWORD2
-SoftPWMSetPercent               KEYWORD2
-SoftPWMSetFadeTime              KEYWORD2
-SoftPWMBegin                    KEYWORD2
-SoftPWMEnd                      KEYWORD2
-SoftPWMSetPolarity              KEYWORD2
+SoftPWMSet	KEYWORD2
+SoftPWMSetPercent	KEYWORD2
+SoftPWMSetFadeTime	KEYWORD2
+SoftPWMBegin	KEYWORD2
+SoftPWMEnd	KEYWORD2
+SoftPWMSetPolarity	KEYWORD2
 
 ########################################
 # Constants (LITERAL2)
 ########################################
 
-ALL                             LITERAL2
-SOFTPWM_NORMAL                  LITERAL2
-SOFTPWM_INVERTED                LITERAL2
+ALL	LITERAL2
+SOFTPWM_NORMAL	LITERAL2
+SOFTPWM_INVERTED	LITERAL2


### PR DESCRIPTION
This adds defines to work with Teensy 32 bit boards.

It also fixes the formatting for keyboards.txt to be compatible with the Arduino IDE (which is quite silly to only allow a single tab between the fields...)